### PR TITLE
fix(ngx-forms): Fix issue with accessor touched and errorsDirective

### DIFF
--- a/apps/opensource/src/app/app.html
+++ b/apps/opensource/src/app/app.html
@@ -18,10 +18,10 @@
 
 <button ngxButton priority="secondary" (click)="showToast()">TOAST</button>
 
-<button ngxButton buttonType="fab" priority="tertiary" icon="fa fa-home"> </button>
+<button ngxButton buttonType="fab" priority="tertiary" icon="fa fa-home"></button>
 
-<button ngxButton buttonType="link">Home</button>
+<button ngxButton buttonType="text">Home</button>
 
-<button ngxButton buttonType="icon" icon="fa fa-home"> </button>
+<button ngxButton buttonType="icon" icon="fa fa-home"></button>
 
 <router-outlet></router-outlet>

--- a/apps/opensource/src/packages/forms/forms.component.html
+++ b/apps/opensource/src/packages/forms/forms.component.html
@@ -1,1 +1,5 @@
 <input *ngxFormsErrors="control" type="text" [formControl]="control" />
+
+<div>
+	<input *ngxFormsErrors="control" ngxInput [formControl]="control" label="Hello" type="text" />
+</div>

--- a/apps/opensource/src/packages/forms/forms.component.ts
+++ b/apps/opensource/src/packages/forms/forms.component.ts
@@ -1,7 +1,11 @@
 import { Component } from '@angular/core';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 
-import { NgxFormsErrorsConfigurationToken, NgxFormsErrorsDirective } from '@lib/ngx-forms';
+import {
+	NgxFormsErrorsConfigurationToken,
+	NgxFormsErrorsDirective,
+	NgxInputDirective,
+} from '@lib/ngx-forms';
 
 @Component({
 	selector: 'ngx-forms-page',
@@ -11,7 +15,7 @@ import { NgxFormsErrorsConfigurationToken, NgxFormsErrorsDirective } from '@lib/
 			useValue: { showWhen: 'touched', errors: { required: 'Dit veld is verplicht' } },
 		},
 	],
-	imports: [ReactiveFormsModule, NgxFormsErrorsDirective],
+	imports: [ReactiveFormsModule, NgxFormsErrorsDirective, NgxInputDirective],
 	templateUrl: './forms.component.html',
 })
 export class FormsPageComponent {

--- a/libs/angular/forms/src/lib/abstracts/custom-control-value-accessor/custom-control-value-accessor.ts
+++ b/libs/angular/forms/src/lib/abstracts/custom-control-value-accessor/custom-control-value-accessor.ts
@@ -1,15 +1,15 @@
 import {
-  ChangeDetectorRef,
-  Directive,
-  Injector,
-  InputSignal,
-  OnDestroy,
-  OutputRef,
-  Signal,
-  effect,
-  inject,
-  input,
-  viewChildren
+	ChangeDetectorRef,
+	Directive,
+	Injector,
+	InputSignal,
+	OnDestroy,
+	OutputRef,
+	Signal,
+	effect,
+	inject,
+	input,
+	viewChildren,
 } from '@angular/core';
 import { outputFromObservable, outputToObservable } from '@angular/core/rxjs-interop';
 import {
@@ -304,7 +304,7 @@ export abstract class NgxFormsControlValueAccessor<
 	 * Mark all controls of the form as touched
 	 */
 	public markAsTouched(options: FormStateOptionsEntity = {}): void {
-		handleFormAccessorMarkAsTouched(this.form, this.accessors as any || [], options);
+		handleFormAccessorMarkAsTouched(this.form, (this.accessors() as any) || [], options);
 
 		// Iben: Detect changes so the changes are visible in the dom
 		this.cdRef.detectChanges();
@@ -314,7 +314,7 @@ export abstract class NgxFormsControlValueAccessor<
 	 * Mark all controls of the form as dirty
 	 */
 	public markAsDirty(options: FormStateOptionsEntity = {}): void {
-		handleFormAccessorMarkAsDirty(this.form, this.accessors() as any || [], options);
+		handleFormAccessorMarkAsDirty(this.form, (this.accessors() as any) || [], options);
 
 		// Iben: Detect changes so the changes are visible in the dom
 		this.cdRef.detectChanges();
@@ -324,7 +324,7 @@ export abstract class NgxFormsControlValueAccessor<
 	 * Mark all controls of the form as pristine
 	 */
 	public markAsPristine(options: FormStateOptionsEntity = {}): void {
-		handleFormAccessorMarkAsPristine(this.form, this.accessors() as any || [], options);
+		handleFormAccessorMarkAsPristine(this.form, (this.accessors() as any) || [], options);
 
 		// Iben: Detect changes so the changes are visible in the dom
 		this.cdRef.detectChanges();
@@ -336,7 +336,7 @@ export abstract class NgxFormsControlValueAccessor<
 	public updateAllValueAndValidity(options: FormStateOptionsEntity): void {
 		handleFormAccessorUpdateValueAndValidity(
 			this.form,
-			this.accessors() as any || [],
+			(this.accessors() as any) || [],
 			options
 		);
 

--- a/libs/angular/forms/src/lib/utils/form-accessor/form-accessor.utils.ts
+++ b/libs/angular/forms/src/lib/utils/form-accessor/form-accessor.utils.ts
@@ -128,7 +128,7 @@ export const handleFormAccessorMarkAsDirty = (
 	}
 
 	// Iben: Loop over each form accessor and call the mark as dirty function, so all subsequent accessors are also marked as dirty
-	accessors.forEach((accessor) => accessor.markAsDirty(options));
+	accessors?.forEach((accessor) => accessor.markAsDirty(options));
 };
 
 /**
@@ -147,7 +147,7 @@ export const handleFormAccessorMarkAsTouched = (
 	form.markAllAsTouched();
 
 	// Iben: Loop over each form accessor and call the mark as touched function, so all subsequent accessors are also marked as touched
-	accessors.forEach((accessor) => accessor.markAsTouched(options));
+	accessors?.forEach((accessor) => accessor.markAsTouched(options));
 };
 
 /**
@@ -166,7 +166,7 @@ export const handleFormAccessorMarkAsPristine = (
 	form.markAsPristine();
 
 	// Iben: Loop over each form accessor and call the mark as touched function, so all subsequent accessors are also marked as touched
-	accessors.forEach((accessor) => accessor.markAsPristine(options));
+	accessors?.forEach((accessor) => accessor.markAsPristine(options));
 };
 
 /**
@@ -185,5 +185,5 @@ export const handleFormAccessorUpdateValueAndValidity = (
 	updateAllValueAndValidity(form, options);
 
 	// Iben: Loop over each form accessor and call the updateValueAndValidity function, so all subsequent accessors are also updated
-	accessors.forEach((accessor) => accessor.updateAllValueAndValidity(options));
+	accessors?.forEach((accessor) => accessor.updateAllValueAndValidity(options));
 };


### PR DESCRIPTION
Fixes two issues:

- The onTouched flow did not correctly implement the signal flow
- The errorsDirective now correctly uses the onDestroy flow.