### PR TITLE
fix(layout): enums were not exposed from layout + fixed a compilation…

### DIFF
--- a/apps/opensource/jest.config.ts
+++ b/apps/opensource/jest.config.ts
@@ -1,21 +1,21 @@
 export default {
-  displayName: 'opensource',
-  preset: '../../jest.preset.js',
-  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-  coverageDirectory: '../../coverage/apps/opensource',
-  transform: {
-    '^.+\\.(ts|mjs|js|html)$': [
-      'jest-preset-angular',
-      {
-        tsconfig: '<rootDir>/tsconfig.spec.json',
-        stringifyContentPathRegex: '\\.(html|svg)$',
-      },
-    ],
-  },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
-  snapshotSerializers: [
-    'jest-preset-angular/build/serializers/no-ng-attributes',
-    'jest-preset-angular/build/serializers/ng-snapshot',
-    'jest-preset-angular/build/serializers/html-comment',
-  ],
+	displayName: 'opensource',
+	preset: '../../jest.preset.js',
+	setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+	coverageDirectory: '../../coverage/apps/opensource',
+	transform: {
+		'^.+\\.(ts|mjs|js|html)$': [
+			'jest-preset-angular',
+			{
+				tsconfig: '<rootDir>/tsconfig.spec.json',
+				stringifyContentPathRegex: '\\.(html|svg)$',
+			},
+		],
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*\\.(mjs|esm\\.js)$)'],
+	snapshotSerializers: [
+		'jest-preset-angular/build/serializers/no-ng-attributes',
+		'jest-preset-angular/build/serializers/ng-snapshot',
+		'jest-preset-angular/build/serializers/html-comment',
+	],
 };

--- a/libs/angular/layout/jest.config.ts
+++ b/libs/angular/layout/jest.config.ts
@@ -1,21 +1,21 @@
 export default {
-  displayName: 'layout',
-  preset: '../../../jest.preset.js',
-  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
-  coverageDirectory: '../../../coverage/libs/angular/layout',
-  transform: {
-    '^.+\\.(ts|mjs|js|html)$': [
-      'jest-preset-angular',
-      {
-        tsconfig: '<rootDir>/tsconfig.spec.json',
-        stringifyContentPathRegex: '\\.(html|svg)$',
-      },
-    ],
-  },
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
-  snapshotSerializers: [
-    'jest-preset-angular/build/serializers/no-ng-attributes',
-    'jest-preset-angular/build/serializers/ng-snapshot',
-    'jest-preset-angular/build/serializers/html-comment',
-  ],
+	displayName: 'layout',
+	preset: '../../../jest.preset.js',
+	setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+	coverageDirectory: '../../../coverage/libs/angular/layout',
+	transform: {
+		'^.+\\.(ts|mjs|js|html)$': [
+			'jest-preset-angular',
+			{
+				tsconfig: '<rootDir>/tsconfig.spec.json',
+				stringifyContentPathRegex: '\\.(html|svg)$',
+			},
+		],
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*\\.(mjs|esm\\.js)$)'],
+	snapshotSerializers: [
+		'jest-preset-angular/build/serializers/no-ng-attributes',
+		'jest-preset-angular/build/serializers/ng-snapshot',
+		'jest-preset-angular/build/serializers/html-comment',
+	],
 };

--- a/libs/angular/layout/src/index.ts
+++ b/libs/angular/layout/src/index.ts
@@ -6,3 +6,4 @@ export * from './lib/providers';
 export * from './lib/directives';
 export * from './lib/guards';
 export * from './lib/pipes';
+export * from './lib/enums';

--- a/libs/angular/layout/src/lib/components/table/ngx-table.component.ts
+++ b/libs/angular/layout/src/lib/components/table/ngx-table.component.ts
@@ -90,7 +90,7 @@ interface TableCellTemplate {
 		NgComponentOutlet,
 	],
 	host: {
-		'class.ngx-table-loading': 'loading()',
+		'[class.ngx-table-loading]': 'loading()',
 	},
 })
 export class NgxTableComponent


### PR DESCRIPTION
Fixed three issues I encountered when trying to switch from `@studiohyperdrive/ngx-table` and `@studiohyperdrive/ngx-layout` to `@ibenvandeveire/ngx-layout`:
1. The enums were not exposed, causing issues where we used (for example) the `NgxTableSortDirection` enum internally.
2. The `.ngx-table-loading` host class was incorrectly set on the `ngx-table.component`. Seeing as this is a single flat ESM bundle, this caused issues for all following functionality (encountered when trying to use the `NgxAccordion`).
3. When running tests, I noticed them failing for two libs, fixed Jest config to get them running.