### PR TITLE
feat(ngx-i18n): preserve route when an invalid language is selected

### DIFF
--- a/libs/angular/i18n/src/lib/guards/i18n/i18n.guard.spec.ts
+++ b/libs/angular/i18n/src/lib/guards/i18n/i18n.guard.spec.ts
@@ -1,5 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, Router, convertToParamMap } from '@angular/router';
+import {
+	ActivatedRouteSnapshot,
+	Router,
+	RouterStateSnapshot,
+	convertToParamMap,
+} from '@angular/router';
 import { subscribeSpyTo } from '@hirez_io/observer-spy';
 import { Observable, of } from 'rxjs';
 
@@ -9,7 +14,7 @@ import { NgxI18nGuard } from './i18n.guard';
 
 describe('NgxI18nGuard', () => {
 	const router: any = {
-		navigate: jest.fn(),
+		navigateByUrl: jest.fn(),
 	};
 	const i18nService: any = {
 		currentLanguage: 'nl',
@@ -35,99 +40,116 @@ describe('NgxI18nGuard', () => {
 		});
 	});
 
-	it(
-        'should return true if the route language matches the currentLanguage',
-        () => {
-            TestBed.runInInjectionContext(() => {
-                let route = {
-                    paramMap: convertToParamMap({ language: 'nl' }),
-                } as ActivatedRouteSnapshot;
+	it('should return true if the route language matches the currentLanguage', () => {
+		TestBed.runInInjectionContext(() => {
+			let route = {
+				paramMap: convertToParamMap({ language: 'nl' }),
+			} as ActivatedRouteSnapshot;
+			let state = { url: '/nl' } as RouterStateSnapshot;
 
-                expect(
-                    subscribeSpyTo(
-                        NgxI18nGuard(route, undefined) as Observable<boolean>
-                    ).getFirstValue()
-                ).toBe(true);
+			expect(
+				subscribeSpyTo(NgxI18nGuard(route, state) as Observable<boolean>).getFirstValue()
+			).toBe(true);
 
-                route = {
-                    parent: {
-                        paramMap: convertToParamMap({ language: 'nl' }),
-                    },
-                    paramMap: convertToParamMap({}),
-                } as ActivatedRouteSnapshot;
+			route = {
+				parent: {
+					paramMap: convertToParamMap({ language: 'nl' }),
+				},
+				paramMap: convertToParamMap({}),
+			} as ActivatedRouteSnapshot;
+			state = { url: '/nl/some/page' } as RouterStateSnapshot;
 
-                expect(
-                    subscribeSpyTo(
-                        NgxI18nGuard(route, undefined) as Observable<boolean>
-                    ).getFirstValue()
-                ).toBe(true);
-            });
-        }
-    );
+			expect(
+				subscribeSpyTo(NgxI18nGuard(route, state) as Observable<boolean>).getFirstValue()
+			).toBe(true);
+		});
+	});
 
-	it(
-        'should set the current language if a new language supported language was provided',
-        () => {
-            TestBed.runInInjectionContext(() => {
-                let route = {
-                    paramMap: convertToParamMap({ language: 'en' }),
-                } as ActivatedRouteSnapshot;
+	it('should set the current language and preserve the rest of the url if a new supported language was provided', () => {
+		TestBed.runInInjectionContext(() => {
+			let route = {
+				paramMap: convertToParamMap({ language: 'en' }),
+			} as ActivatedRouteSnapshot;
+			let state = { url: '/en/some/page' } as RouterStateSnapshot;
 
-                expect(
-                    subscribeSpyTo(
-                        NgxI18nGuard(route, undefined) as Observable<boolean>
-                    ).getFirstValue()
-                ).toBe(true);
-                expect(i18nService.setCurrentLanguage).toHaveBeenCalledWith('en');
-                expect(router.navigate).toHaveBeenCalledWith(['/', 'en']);
+			expect(
+				subscribeSpyTo(NgxI18nGuard(route, state) as Observable<boolean>).getFirstValue()
+			).toBe(true);
+			expect(i18nService.setCurrentLanguage).toHaveBeenCalledWith('en');
+			expect(router.navigateByUrl).toHaveBeenCalledWith('/en/some/page');
 
-                route = {
-                    parent: {
-                        paramMap: convertToParamMap({ language: 'en' }),
-                    },
-                    paramMap: convertToParamMap({}),
-                } as ActivatedRouteSnapshot;
+			route = {
+				parent: {
+					paramMap: convertToParamMap({ language: 'en' }),
+				},
+				paramMap: convertToParamMap({}),
+			} as ActivatedRouteSnapshot;
+			state = { url: '/en/nested/page' } as RouterStateSnapshot;
 
-                expect(
-                    subscribeSpyTo(
-                        NgxI18nGuard(route, undefined) as Observable<boolean>
-                    ).getFirstValue()
-                ).toBe(true);
-                expect(i18nService.setCurrentLanguage).toHaveBeenCalledWith('en');
-                expect(router.navigate).toHaveBeenCalledWith(['/', 'en']);
-            });
-        }
-    );
+			expect(
+				subscribeSpyTo(NgxI18nGuard(route, state) as Observable<boolean>).getFirstValue()
+			).toBe(true);
+			expect(i18nService.setCurrentLanguage).toHaveBeenCalledWith('en');
+			expect(router.navigateByUrl).toHaveBeenCalledWith('/en/nested/page');
+		});
+	});
 
-	it(
-        'should redirect to the currently set language if the language is not supported',
-        () => {
-            TestBed.runInInjectionContext(() => {
-                let route = {
-                    paramMap: convertToParamMap({ language: 'de' }),
-                } as ActivatedRouteSnapshot;
+	it('should redirect to the currently set language while preserving the rest of the url if the language is not supported', () => {
+		TestBed.runInInjectionContext(() => {
+			let route = {
+				paramMap: convertToParamMap({ language: 'de' }),
+			} as ActivatedRouteSnapshot;
+			let state = { url: '/de/pagina/toegankelijkheid' } as RouterStateSnapshot;
 
-                expect(
-                    subscribeSpyTo(
-                        NgxI18nGuard(route, undefined) as Observable<boolean>
-                    ).getFirstValue()
-                ).toBe(false);
-                expect(router.navigate).toHaveBeenCalledWith(['/', 'nl']);
+			expect(
+				subscribeSpyTo(NgxI18nGuard(route, state) as Observable<boolean>).getFirstValue()
+			).toBe(false);
+			expect(router.navigateByUrl).toHaveBeenCalledWith('/nl/pagina/toegankelijkheid');
 
-                route = {
-                    parent: {
-                        paramMap: convertToParamMap({ language: 'de' }),
-                    },
-                    paramMap: convertToParamMap({}),
-                } as ActivatedRouteSnapshot;
+			route = {
+				parent: {
+					paramMap: convertToParamMap({ language: 'de' }),
+				},
+				paramMap: convertToParamMap({}),
+			} as ActivatedRouteSnapshot;
+			state = { url: '/de/nested/page' } as RouterStateSnapshot;
 
-                expect(
-                    subscribeSpyTo(
-                        NgxI18nGuard(route, undefined) as Observable<boolean>
-                    ).getFirstValue()
-                ).toBe(false);
-                expect(router.navigate).toHaveBeenCalledWith(['/', 'nl']);
-            });
-        }
-    );
+			expect(
+				subscribeSpyTo(NgxI18nGuard(route, state) as Observable<boolean>).getFirstValue()
+			).toBe(false);
+			expect(router.navigateByUrl).toHaveBeenCalledWith('/nl/nested/page');
+		});
+	});
+
+	it('should redirect to the bare current language when the attempted url has no segments to preserve', () => {
+		TestBed.runInInjectionContext(() => {
+			const route = {
+				paramMap: convertToParamMap({ language: 'de' }),
+			} as ActivatedRouteSnapshot;
+			const state = { url: '/de' } as RouterStateSnapshot;
+
+			expect(
+				subscribeSpyTo(NgxI18nGuard(route, state) as Observable<boolean>).getFirstValue()
+			).toBe(false);
+			expect(router.navigateByUrl).toHaveBeenCalledWith('/nl');
+		});
+	});
+
+	it('should preserve query strings when redirecting an unsupported language', () => {
+		TestBed.runInInjectionContext(() => {
+			const route = {
+				paramMap: convertToParamMap({ language: 'undefined' }),
+			} as ActivatedRouteSnapshot;
+			const state = {
+				url: '/undefined/pagina/toegankelijkheid?foo=bar',
+			} as RouterStateSnapshot;
+
+			expect(
+				subscribeSpyTo(NgxI18nGuard(route, state) as Observable<boolean>).getFirstValue()
+			).toBe(false);
+			expect(router.navigateByUrl).toHaveBeenCalledWith(
+				'/nl/pagina/toegankelijkheid?foo=bar'
+			);
+		});
+	});
 });

--- a/libs/angular/i18n/src/lib/guards/i18n/i18n.guard.ts
+++ b/libs/angular/i18n/src/lib/guards/i18n/i18n.guard.ts
@@ -1,5 +1,10 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
+import {
+	ActivatedRouteSnapshot,
+	CanActivateFn,
+	Router,
+	RouterStateSnapshot,
+} from '@angular/router';
 import { Observable, take, map } from 'rxjs';
 
 import { NgxI18nRootService } from '../../services';
@@ -9,7 +14,10 @@ import { NgxI18nRootService } from '../../services';
  *
  * @param route - The provided route
  */
-export const NgxI18nGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Observable<boolean> => {
+export const NgxI18nGuard: CanActivateFn = (
+	route: ActivatedRouteSnapshot,
+	state: RouterStateSnapshot
+): Observable<boolean> => {
 	// Iben: Fetch all injectables
 	const router: Router = inject(Router);
 	const i18nService = inject(NgxI18nRootService);
@@ -39,13 +47,13 @@ export const NgxI18nGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Obse
 				i18nService.setCurrentLanguage(routeLanguage);
 
 				//Iben: Re-route to the new language
-				router.navigate(['/', routeLanguage]);
+				router.navigateByUrl(replaceLanguageSegment(state.url, routeLanguage));
 
 				return true;
 			}
 
 			//Iben: The current language is set to "default" when no previous language exists.
-			router.navigate(['/', currentLanguage]);
+			router.navigateByUrl(replaceLanguageSegment(state.url, currentLanguage));
 
 			return false;
 		})
@@ -53,10 +61,14 @@ export const NgxI18nGuard: CanActivateFn = (route: ActivatedRouteSnapshot): Obse
 };
 
 /**
+ * getLanguage
+ *
  * Fetches the language from the route
  *
  * @param route - The provided route
  * @param config - The provided config
+ *
+ * @returns the language that has been extracted from the requested route.
  */
 const getLanguage = (
 	route: ActivatedRouteSnapshot,
@@ -75,4 +87,24 @@ const getLanguage = (
 	}
 
 	return getLanguage(parent, availableLanguages, languageRouteParam);
+};
+
+/**
+ * replaceLanguageSegment
+ *
+ * Swaps the first path segment (the language) of an attempted URL for the resolved language,
+ * keeping everything after it (remaining path segments, matrix params, query string and fragment)
+ * intact instead of redirecting to the bare `/<language>` root.
+ *
+ * @param url - The url that needs to be transformed.
+ * @param language - The target language for the url.
+ *
+ * @returns the existing url that had an unexisting language param,
+ * where that param has been replaced with an existing/the desired language.
+ */
+const replaceLanguageSegment = (url: string, language: string): string => {
+	const nextSegmentStart = url.indexOf('/', 1);
+	const rest = nextSegmentStart === -1 ? '' : url.slice(nextSegmentStart);
+
+	return `/${language}${rest}`;
 };


### PR DESCRIPTION
Hi

In the i18n-guard, if the language param doesn't match, I would try to preserve the route instead of correcting the language param and redirecting to the root route.

Take a look, and let me know what you think. It is just a suggestion and I'm open to iteration/rework or brainstorming other approaches of course.

FYI: the unit testing has been updated with help from Claude Code.